### PR TITLE
Update modules to support Terraform 0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
   enabled     = var.enabled
   namespace   = var.namespace
   name        = var.name
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 }
 
 module "dns" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.8.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = var.name
   ttl     = 60


### PR DESCRIPTION

## what
Update modules to support Terraform 0.14:
* cloudposse/terraform-null-label to 0.22.0
* cloudposse/terraform-aws-route53-cluster-hostname to 0.8.0

## why
Using modules compatible with Terraform 0.14



