### PR TITLE
fix: sg arn output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "security_group_id" {
 }
 
 output "security_group_arn" {
-  value       = join("", module.aws_security_group[*].arn)
+  value       = try(module.aws_security_group[*].arn, null)
   description = "The ARN of the created security group"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "security_group_id" {
 }
 
 output "security_group_arn" {
-  value       = try(module.aws_security_group[*].arn, null)
+  value       = module.aws_security_group.arn
   description = "The ARN of the created security group"
 }
 


### PR DESCRIPTION
## what
* When you're using external sg with setting `create_security_group = false` and don't want to create default one which is included in module you get response with nullable element and can't concatenate null values.

```hcl
│ Error: Invalid function argument
│ 
│   on .terraform/modules/elasticache_memcached/outputs.tf line 12, in output "security_group_arn":
│   12:   value       = join("", module.aws_security_group[*].arn)
│     ├────────────────
│     │ while calling join(separator, lists...)
│     │ module.aws_security_group is object with 4 attributes
│ 
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate null values.
``` 

