### PR TITLE
fix: sg arn output breaks when providing security groups IDs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "security_group_id" {
 }
 
 output "security_group_arn" {
-  value       = join("", module.aws_security_group[*].arn)
+  value       = module.aws_security_group.arn
   description = "The ARN of the created security group"
 }
 


### PR DESCRIPTION
## what

Currently a `join()` is run over what is assumed to be all of the created security groups created by the `module.aws_security_group`. This join fails when there are no security groups being created. What's more, my reading is that only one security group will ever be created, so only one security group ID should ever need to be extracted, so this is probably a leftover from older logic.

## why

When using `create_security_group = false` and `associated_security_groups = [<something>] `, the module fails with
```
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate
│ null values.
```
This breaks a documented supported configuration (that we happen to use and be blocked by).

## references

This is just putting the fix from https://github.com/dmitrijn/terraform-aws-elasticache-memcached per the request in https://github.com/cloudposse/terraform-aws-elasticache-memcached/pull/56#issuecomment-1936558515 to get this fix into main.
