### PR TITLE
Set correct required version of AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.16 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.16 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.16 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.16 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.16"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what

Sets the required AWS provider version to v5.16, the minimal requirement for use of the module.

## why

With the introduction of the `transit_encryption_enabled` variable this module now requires AWS provider v5.16, as [that is the version to introduce that attribute](https://github.com/hashicorp/terraform-provider-aws/blob/v5.16.0/CHANGELOG.md) to the `aws_elasticache_cluster` resource.

## references

* [AWS Provider v5.16 changelog](https://github.com/hashicorp/terraform-provider-aws/blob/v5.16.0/CHANGELOG.md)